### PR TITLE
added logic to protect the .media folder used by themes

### DIFF
--- a/ui/archive_create.go
+++ b/ui/archive_create.go
@@ -47,6 +47,11 @@ func (acs ArchiveCreateScreen) Draw() (value interface{}, exitCode int, e error)
 
 		newArchiveName = utils.PrepArchiveName(newArchiveName)
 
+		if newArchiveName == ".media" {
+			utils.ShowTimedMessage(".media folder is reserved for themes.\nPlease choose a different name.", time.Second*2)
+			return nil, 0, nil
+		}
+
 		dirErr := utils.EnsureDirectoryExists(utils.GetArchiveRoot(newArchiveName))
 
 		message := fmt.Sprintf("Created %s!", newArchiveName)

--- a/utils/functions.go
+++ b/utils/functions.go
@@ -90,7 +90,9 @@ func GetArchiveFileListBasic() ([]string, error) {
 		folderName := folder.Name()
 		if directoryExists(filepath.Join(GetRomDirectory(), folderName)) {
 			if strings.HasPrefix(folderName, ".") {
-				archiveFolders = append(archiveFolders, folderName)
+				if folderName != ".media" {
+					archiveFolders = append(archiveFolders, folderName)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
.media folder is used by themes and should not be used for archiving purposes. Users should ensure they have not archived any games to .media since release 2.1.0. If they have, they should restore the archived games prior to updating as this change will prevent access to the .media folder.