### PR TITLE
Play History Filter

### DIFF
--- a/app/game_manager.go
+++ b/app/game_manager.go
@@ -193,7 +193,7 @@ func handlePlayHistoryFilterTransition(currentScreen models.Screen, result inter
 }
 
 func handlePlayHistoryListTransition(currentScreen models.Screen, result interface{}, code int) models.Screen {
-	phls := currentScreen.(ui.PlayHistoryGamesListScreen)
+	phls := currentScreen.(ui.PlayHistoryListScreen)
 	switch code {
 	case ExitCodeSuccess:
 		state.AddNewMenuPosition()

--- a/app/game_manager.go
+++ b/app/game_manager.go
@@ -175,6 +175,12 @@ func handlePlayHistoryFilterTransition(currentScreen models.Screen, result inter
 			append(phfs.PlayHistoryFilterList, newFilter), phfs.MenuDepth+1)
 	case ExitCodeCancel:
 		if len(phfs.PlayHistoryFilterList) > 0 {
+			if phfs.MenuDepth > 1 {
+				state.RemoveMenuPositions(1)
+				return ui.InitPlayHistoryFilterScreen(phfs.Console, phfs.SearchFilter, phfs.GameAggregate, 
+					phfs.Game, phfs.RomDirectory, phfs.PreviousRomDirectory, phfs.PlayHistoryOrigin, 
+					phfs.PlayHistoryFilterList[:len(phfs.PlayHistoryFilterList)-1], phfs.MenuDepth-1)
+			}
 			state.UpdateCurrentMenuPosition(0, 0)
 			return ui.InitPlayHistoryFilterScreen(phfs.Console, phfs.SearchFilter, phfs.GameAggregate, 
 				phfs.Game, phfs.RomDirectory, phfs.PreviousRomDirectory, phfs.PlayHistoryOrigin, 
@@ -182,11 +188,12 @@ func handlePlayHistoryFilterTransition(currentScreen models.Screen, result inter
 		}
 	}
 	state.RemoveMenuPositions(phfs.MenuDepth)
+	state.UpdateCurrentMenuPosition(0, 0)
 	if phfs.Console == "" {
 		return ui.InitPlayHistoryListScreen(phfs.PlayHistoryFilterList)
 	}
 	if phfs.GameAggregate.Name == "" {
-		ui.InitPlayHistoryGamesListScreen(phfs.Console, phfs.PlayHistoryFilterList)
+		return ui.InitPlayHistoryGamesListScreen(phfs.Console, phfs.PlayHistoryFilterList)
 	}
 	return ui.InitPlayHistoryGameHistoryScreen(phfs.Console, phfs.SearchFilter, phfs.GameAggregate, 
 		phfs.Game, phfs.RomDirectory, phfs.PreviousRomDirectory, phfs.PlayHistoryOrigin, phfs.PlayHistoryFilterList)

--- a/app/game_manager.go
+++ b/app/game_manager.go
@@ -186,6 +186,9 @@ func handlePlayHistoryFilterTransition(currentScreen models.Screen, result inter
 				phfs.Game, phfs.RomDirectory, phfs.PreviousRomDirectory, phfs.PlayHistoryOrigin, 
 				phfs.PlayHistoryFilterList[:len(phfs.PlayHistoryFilterList)-1], phfs.MenuDepth)
 		}
+		return ui.InitPlayHistoryFilterScreen(phfs.Console, phfs.SearchFilter, phfs.GameAggregate, 
+			phfs.Game, phfs.RomDirectory, phfs.PreviousRomDirectory, phfs.PlayHistoryOrigin, 
+			phfs.PlayHistoryFilterList, phfs.MenuDepth)
 	}
 	state.RemoveMenuPositions(phfs.MenuDepth)
 	state.UpdateCurrentMenuPosition(0, 0)

--- a/app/game_manager.go
+++ b/app/game_manager.go
@@ -149,24 +149,58 @@ func handleScreenTransition(currentScreen models.Screen, result interface{}, cod
 	case models.ScreenNames.ArchiveOptions:
 		return handleArchiveOptionsTransition(currentScreen, result, code)
 	case models.ScreenNames.PlayHistoryList:
-		return handlePlayHistoryListTransition(result, code)
+		return handlePlayHistoryListTransition(currentScreen, result, code)
 	case models.ScreenNames.PlayHistoryGameList:
 		return handlePlayHistoryGameListTransition(currentScreen, result, code)
 	case models.ScreenNames.PlayHistoryGameDetails:
 		return handlePlayHistoryGameDetailsTransition(currentScreen, result, code)
 	case models.ScreenNames.PlayHistoryGameHistory:
 		return handlePlayHistoryGameHistoryTransition(currentScreen, result, code)
+	case models.ScreenNames.PlayHistoryFilter:
+		return handlePlayHistoryFilterTransition(currentScreen, result, code)
 	default:
 		state.ReturnToMain()
 		return ui.InitMainMenu()
 	}
 }
 
-func handlePlayHistoryListTransition(result interface{}, code int) models.Screen {
+func handlePlayHistoryFilterTransition(currentScreen models.Screen, result interface{}, code int) models.Screen {
+	phfs := currentScreen.(ui.PlayHistoryFilterScreen)
+	switch code {
+	case ExitCodeSuccess:
+		newFilter := result.(models.PlayHistorySearchFilter)
+		state.AddNewMenuPosition()
+		return ui.InitPlayHistoryFilterScreen(phfs.Console, phfs.SearchFilter, phfs.GameAggregate, 
+			phfs.Game, phfs.RomDirectory, phfs.PreviousRomDirectory, phfs.PlayHistoryOrigin, 
+			append(phfs.PlayHistoryFilterList, newFilter), phfs.MenuDepth+1)
+	case ExitCodeCancel:
+		if len(phfs.PlayHistoryFilterList) > 0 {
+			state.UpdateCurrentMenuPosition(0, 0)
+			return ui.InitPlayHistoryFilterScreen(phfs.Console, phfs.SearchFilter, phfs.GameAggregate, 
+				phfs.Game, phfs.RomDirectory, phfs.PreviousRomDirectory, phfs.PlayHistoryOrigin, 
+				phfs.PlayHistoryFilterList[:len(phfs.PlayHistoryFilterList)-1], phfs.MenuDepth)
+		}
+	}
+	state.RemoveMenuPositions(phfs.MenuDepth)
+	if phfs.Console == "" {
+		return ui.InitPlayHistoryListScreen(phfs.PlayHistoryFilterList)
+	}
+	if phfs.GameAggregate.Name == "" {
+		ui.InitPlayHistoryGamesListScreen(phfs.Console, phfs.PlayHistoryFilterList)
+	}
+	return ui.InitPlayHistoryGameHistoryScreen(phfs.Console, phfs.SearchFilter, phfs.GameAggregate, 
+		phfs.Game, phfs.RomDirectory, phfs.PreviousRomDirectory, phfs.PlayHistoryOrigin, phfs.PlayHistoryFilterList)
+}
+
+func handlePlayHistoryListTransition(currentScreen models.Screen, result interface{}, code int) models.Screen {
+	phls := currentScreen.(ui.PlayHistoryGamesListScreen)
 	switch code {
 	case ExitCodeSuccess:
 		state.AddNewMenuPosition()
-		return ui.InitPlayHistoryGamesListScreen(result.(string), "")
+		return ui.InitPlayHistoryGamesListScreen(result.(string), phls.PlayHistoryFilterList)
+	case ExitCodeAction:
+		state.AddNewMenuPosition()
+		return ui.InitPlayHistoryFilterScreenFromHistoryList(phls.PlayHistoryFilterList)
 	default:
 		state.RemoveMenuPositions(1)
 		return ui.InitToolsScreen()
@@ -179,44 +213,38 @@ func handlePlayHistoryGameListTransition(currentScreen models.Screen, result int
 	switch code {
 	case ExitCodeSuccess:
 		state.AddNewMenuPosition()
-		return ui.InitPlayHistoryGameDetailsScreenFromPlayHistory(ptgls.Console, ptgls.SearchFilter, result.(models.PlayHistoryAggregate))
+		return ui.InitPlayHistoryGameDetailsScreenFromPlayHistory(ptgls.Console, result.(models.PlayHistoryAggregate), ptgls.PlayHistoryFilterList)
 	case ExitCodeCancel:
-		if ptgls.SearchFilter != "" {
-			state.UpdateCurrentMenuPosition(0, 0)
-			return ui.InitPlayHistoryGamesListScreen(ptgls.Console, "")
-		}
-
 		state.RemoveMenuPositions(1)
-		return ui.InitPlayHistoryListScreen()
-	case ExitCodeAction, ExitCodeError:
-		searchFilter := result.(string)
-
-		if searchFilter != "" {
-			state.UpdateCurrentMenuPosition(0, 0)
-			return ui.InitPlayHistoryGamesListScreen(ptgls.Console, searchFilter)
-		}
-
-		return ui.InitPlayHistoryGamesListScreen(ptgls.Console, "")
+		return ui.InitPlayHistoryListScreen(ptgls.PlayHistoryFilterList)
+	case ExitCodeAction:
+		state.AddNewMenuPosition()
+		return ui.InitPlayHistoryFilterScreenFromGameList(ptgls.Console, ptgls.PlayHistoryFilterList)
 	case ExitCodeEmpty:
-		if ptgls.SearchFilter != "" {
-			utils.ShowTimedMessage(fmt.Sprintf("No results found for %s!", ptgls.SearchFilter), shortMessageDelay)
-			state.UpdateCurrentMenuPosition(0, 0)
-			return ui.InitPlayHistoryGamesListScreen(ptgls.Console, "")
-		}
-
 		utils.ShowTimedMessage(fmt.Sprintf("%s history is empty!", ptgls.Console), longMessageDelay)
 		state.RemoveMenuPositions(1)
-		return ui.InitPlayHistoryListScreen()
+		return ui.InitPlayHistoryListScreen(ptgls.PlayHistoryFilterList)
 	default:
 		state.RemoveMenuPositions(1)
-		return ui.InitPlayHistoryListScreen()
+		return ui.InitPlayHistoryListScreen(ptgls.PlayHistoryFilterList)
 	}
 }
 
 func handlePlayHistoryGameHistoryTransition(currentScreen models.Screen, result interface{}, code int) models.Screen {
 	ptghs := currentScreen.(ui.PlayHistoryGameHistoryScreen)
-	return ui.InitPlayHistoryGameDetailsScreenFromSelf(ptghs.Console, ptghs.SearchFilter, ptghs.GameAggregate, 
-		ptghs.Game, ptghs.RomDirectory, ptghs.PreviousRomDirectory, ptghs.PlayHistoryOrigin)
+
+	switch code {
+	case ExitCodeSuccess:
+		return ui.InitPlayHistoryGameHistoryScreen(ptghs.Console, ptghs.SearchFilter, ptghs.GameAggregate, 
+			ptghs.Game, ptghs.RomDirectory, ptghs.PreviousRomDirectory, ptghs.PlayHistoryOrigin, ptghs.PlayHistoryFilterList)
+	case ExitCodeAction:
+		state.AddNewMenuPosition()
+		return ui.InitPlayHistoryFilterScreen(ptghs.Console, ptghs.SearchFilter, ptghs.GameAggregate, 
+			ptghs.Game, ptghs.RomDirectory, ptghs.PreviousRomDirectory, ptghs.PlayHistoryOrigin, ptghs.PlayHistoryFilterList, 1)
+	default:
+		return ui.InitPlayHistoryGameDetailsScreenFromSelf(ptghs.Console, ptghs.SearchFilter, ptghs.GameAggregate, 
+			ptghs.Game, ptghs.RomDirectory, ptghs.PreviousRomDirectory, ptghs.PlayHistoryOrigin, ptghs.PlayHistoryFilterList)
+	}
 }
 
 func handlePlayHistoryGameDetailsTransition(currentScreen models.Screen, result interface{}, code int) models.Screen {
@@ -224,11 +252,11 @@ func handlePlayHistoryGameDetailsTransition(currentScreen models.Screen, result 
 	switch code {
 	case ExitCodeSuccess:
 		return ui.InitPlayHistoryGameHistoryScreen(ptgds.Console, ptgds.SearchFilter, ptgds.GameAggregate, 
-		ptgds.Game, ptgds.RomDirectory, ptgds.PreviousRomDirectory, ptgds.PlayHistoryOrigin)
+		ptgds.Game, ptgds.RomDirectory, ptgds.PreviousRomDirectory, ptgds.PlayHistoryOrigin, ptgds.PlayHistoryFilterList)
 	default:
 		state.RemoveMenuPositions(1)
 		if ptgds.PlayHistoryOrigin {
-			return ui.InitPlayHistoryGamesListScreen(ptgds.Console, ptgds.SearchFilter)
+			return ui.InitPlayHistoryGamesListScreen(ptgds.Console, ptgds.PlayHistoryFilterList)
 		}
 		return ui.InitActionsScreen(ptgds.Game, ptgds.RomDirectory, ptgds.PreviousRomDirectory, ptgds.SearchFilter)
 	}
@@ -421,7 +449,7 @@ func handleToolsTransition(result interface{}, code int) models.Screen {
 		case "Global Actions":
 			return ui.InitGlobalActionsScreen()
 		case "Play History":
-			return ui.InitPlayHistoryListScreen()
+			return ui.InitPlayHistoryListScreen(nil)
 		}
 		return ui.InitToolsScreen()
 	case ExitCodeAction:

--- a/models/play_history.go
+++ b/models/play_history.go
@@ -17,3 +17,10 @@ type PlayHistoryGranular struct {
 	StartTime	int
 	UpdateTime	int
 }
+
+type PlayHistorySearchFilter struct {
+	DisplayName	string
+	SqlFilter	string
+	FilterType	int
+	PlayTime	int
+}

--- a/models/screens.go
+++ b/models/screens.go
@@ -32,6 +32,7 @@ type ScreenName struct {
 	PlayHistoryGameHistory,
 	PlayHistoryGameList,
 	PlayHistoryList,
+	PlayHistoryFilter,
 
 	GlobalActions sum.Int[ScreenName]
 }

--- a/state/state.go
+++ b/state/state.go
@@ -124,7 +124,7 @@ func GetPlayMaps() (map[string][]models.PlayHistoryAggregate, map[string]int, in
 
 func updatePlayMaps() {
 	temp := GetAppState()
-	temp.GamePlayMap, temp.ConsolePlayMap, temp.TotalPlay = utils.GenerateCurrentGameStats()
+	temp.GamePlayMap, temp.ConsolePlayMap, temp.TotalPlay = utils.GenerateCurrentGameStats("")
 	UpdateAppState(temp)
 }
 

--- a/ui/play_history_filter.go
+++ b/ui/play_history_filter.go
@@ -107,6 +107,7 @@ func (phfs PlayHistoryFilterScreen) Draw() (item interface{}, exitCode int, e er
 	options.VisibleStartIndex = visibleStartIndex
 
 	options.EnableAction = true
+	options.SmallTitle = true
 	options.EmptyMessage = "Max Filter Depth\nX to save filter"
 	options.FooterHelpItems = []gaba.FooterHelpItem{
 		{ButtonName: "B", HelpText: "Back"},

--- a/ui/play_history_filter.go
+++ b/ui/play_history_filter.go
@@ -1,0 +1,131 @@
+package ui
+
+import (
+	"fmt"
+	gaba "github.com/UncleJunVIP/gabagool/pkg/gabagool"
+	shared "github.com/UncleJunVIP/nextui-pak-shared-functions/models"
+	"nextui-game-manager/models"
+	"nextui-game-manager/state"
+	"nextui-game-manager/utils"
+	"qlova.tech/sum"
+)
+
+type PlayHistoryFilterScreen struct {
+	Console         		string
+	SearchFilter			string
+	GameAggregate			models.PlayHistoryAggregate
+	Game                 	shared.Item
+	RomDirectory         	shared.RomDirectory
+	PreviousRomDirectory 	shared.RomDirectory
+	PlayHistoryOrigin		bool
+	PlayHistoryFilterList	[]models.PlayHistorySearchFilter
+	MenuDepth				int
+}
+
+func InitPlayHistoryFilterScreen(console string, searchFilter string, gameAggregate models.PlayHistoryAggregate, game shared.Item, romDirectory shared.RomDirectory, 
+	previousRomDirectory shared.RomDirectory, playHistoryOrigin bool, filterList []models.PlayHistorySearchFilter, menuDepth int) PlayHistoryFilterScreen {
+	return PlayHistoryFilterScreen{
+		Console:              	console,
+		SearchFilter:         	searchFilter,
+		GameAggregate: 			gameAggregate,
+		Game:      				game,
+		RomDirectory: 			romDirectory,
+		PreviousRomDirectory:	previousRomDirectory,
+		PlayHistoryOrigin: 		playHistoryOrigin,
+		PlayHistoryFilterList:	filterList,
+		MenuDepth:				menuDepth,
+	}
+}
+
+func InitPlayHistoryFilterScreenFromGameList(console string, filterList []models.PlayHistorySearchFilter) PlayHistoryFilterScreen {
+	return PlayHistoryFilterScreen{
+		Console:              	console,
+		PlayHistoryFilterList:	filterList,
+		MenuDepth:				1,
+	}
+}
+
+func InitPlayHistoryFilterScreenFromHistoryList(filterList []models.PlayHistorySearchFilter) PlayHistoryFilterScreen {
+	return PlayHistoryFilterScreen{
+		PlayHistoryFilterList:	filterList,
+		MenuDepth:				1,
+	}
+}
+
+func (phfs PlayHistoryFilterScreen) Name() sum.Int[models.ScreenName] {
+	return models.ScreenNames.PlayHistoryFilter
+}
+
+// Lists available play History consoles
+func (phfs PlayHistoryFilterScreen) Draw() (item interface{}, exitCode int, e error) {
+	title := "Select a Filter"
+
+	romIds := []int{}
+	if len(phfs.GameAggregate.Id) > 0 {
+		romIds = phfs.GameAggregate.Id
+		title = phfs.GameAggregate.Name
+	} else if phfs.Console != "" {
+		gamePlayMap, _, _ := state.GetPlayMaps()
+		gamesList := gamePlayMap[phfs.Console]
+		for _, game := range gamesList {
+			romIds = append(romIds, game.Id...)
+		}
+		title = phfs.Console
+	}
+
+	currentFilter := models.PlayHistorySearchFilter{}
+	if len(phfs.PlayHistoryFilterList) != 0 {
+		currentFilter = phfs.PlayHistoryFilterList[len(phfs.PlayHistoryFilterList)-1]
+		if title == "Select a Filter" {
+			title = currentFilter.DisplayName
+		} else {
+			title = currentFilter.DisplayName + " : " + title
+		}
+	}
+
+	filterList := []models.PlayHistorySearchFilter{}
+	if currentFilter.FilterType < 2 {
+		filterList = utils.GenFiltersList(romIds, currentFilter.SqlFilter, currentFilter.FilterType)
+	}
+
+	var menuItems []gaba.MenuItem
+	
+	for _, filter := range filterList {
+		filterItem := gaba.MenuItem{
+			Text:     fmt.Sprintf("%s : %.1fH",filter.DisplayName, min(9999, float64(filter.PlayTime)/3600.0)),
+			Selected: false,
+			Focused:  false,
+			Metadata: filter,
+		}
+		menuItems = append(menuItems, filterItem)
+	}
+
+	options := gaba.DefaultListOptions(title, menuItems)
+
+	selectedIndex, visibleStartIndex := state.GetCurrentMenuPosition()
+	options.SelectedIndex = selectedIndex
+	options.VisibleStartIndex = visibleStartIndex
+
+	options.EnableAction = true
+	options.EmptyMessage = "Max Filter Depth\nX to save filter"
+	options.FooterHelpItems = []gaba.FooterHelpItem{
+		{ButtonName: "B", HelpText: "Back"},
+		{ButtonName: "X", HelpText: "Save Filter"},
+		{ButtonName: "A", HelpText: "Select"},
+	}
+
+	selection, err := gaba.List(options)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	if selection.IsSome() && selection.Unwrap().ActionTriggered {
+		return nil, 4, nil
+	} else if selection.IsSome() && !selection.Unwrap().ActionTriggered && selection.Unwrap().SelectedIndex != -1 {
+		state.UpdateCurrentMenuPosition(selection.Unwrap().SelectedIndex, selection.Unwrap().VisiblePosition)
+		newFilter := selection.Unwrap().SelectedItem.Metadata.(models.PlayHistorySearchFilter)
+		return newFilter, 0, nil
+	}
+
+	return nil, 2, nil
+}

--- a/ui/play_history_filter.go
+++ b/ui/play_history_filter.go
@@ -58,29 +58,25 @@ func (phfs PlayHistoryFilterScreen) Name() sum.Int[models.ScreenName] {
 
 // Lists available play History consoles
 func (phfs PlayHistoryFilterScreen) Draw() (item interface{}, exitCode int, e error) {
-	title := "Select a Filter"
+	title := "Filter"
+
+	currentFilter := models.PlayHistorySearchFilter{}
+	if len(phfs.PlayHistoryFilterList) != 0 {
+		currentFilter = phfs.PlayHistoryFilterList[len(phfs.PlayHistoryFilterList)-1]
+		title = title + ": " + currentFilter.DisplayName
+	}
 
 	romIds := []int{}
 	if len(phfs.GameAggregate.Id) > 0 {
 		romIds = phfs.GameAggregate.Id
-		title = phfs.GameAggregate.Name
+		title = title + " (" + phfs.GameAggregate.Name[:min(10, len(phfs.GameAggregate.Name))] + ")"
 	} else if phfs.Console != "" {
 		gamePlayMap, _, _ := state.GetPlayMaps()
 		gamesList := gamePlayMap[phfs.Console]
 		for _, game := range gamesList {
 			romIds = append(romIds, game.Id...)
 		}
-		title = phfs.Console
-	}
-
-	currentFilter := models.PlayHistorySearchFilter{}
-	if len(phfs.PlayHistoryFilterList) != 0 {
-		currentFilter = phfs.PlayHistoryFilterList[len(phfs.PlayHistoryFilterList)-1]
-		if title == "Select a Filter" {
-			title = currentFilter.DisplayName
-		} else {
-			title = currentFilter.DisplayName + " : " + title
-		}
+		title = title + " (" + phfs.Console[:min(10, len(phfs.Console))] + ")"
 	}
 
 	filterList := []models.PlayHistorySearchFilter{}
@@ -107,7 +103,7 @@ func (phfs PlayHistoryFilterScreen) Draw() (item interface{}, exitCode int, e er
 	options.VisibleStartIndex = visibleStartIndex
 
 	options.EnableAction = true
-	options.SmallTitle = true
+	//options.SmallTitle = true
 	options.EmptyMessage = "Max Filter Depth\nX to save filter"
 	options.FooterHelpItems = []gaba.FooterHelpItem{
 		{ButtonName: "B", HelpText: "Back"},

--- a/ui/play_history_filter.go
+++ b/ui/play_history_filter.go
@@ -135,6 +135,5 @@ func (phfs PlayHistoryFilterScreen) Draw() (item interface{}, exitCode int, e er
 		return newFilter, 0, nil
 	}
 
-	state.UpdateCurrentMenuPosition(selection.Unwrap().SelectedIndex, selection.Unwrap().VisiblePosition)
 	return nil, 2, nil
 }

--- a/ui/play_history_filter.go
+++ b/ui/play_history_filter.go
@@ -83,7 +83,7 @@ func (phfs PlayHistoryFilterScreen) Draw() (item interface{}, exitCode int, e er
 		if startIndex == -1 || endIndex == -1 || startIndex >= endIndex {
 			title = title + " (" + phfs.Console + ")"
 		} else {
-			title = title + phfs.Console[startIndex : endIndex+1]
+			title = title + " " + phfs.Console[startIndex : endIndex+1]
 		}
 	}
 

--- a/ui/play_history_filter.go
+++ b/ui/play_history_filter.go
@@ -106,9 +106,12 @@ func (phfs PlayHistoryFilterScreen) Draw() (item interface{}, exitCode int, e er
 	//options.SmallTitle = true
 	options.EmptyMessage = "Max Filter Depth\nX to save filter"
 	options.FooterHelpItems = []gaba.FooterHelpItem{
-		{ButtonName: "B", HelpText: "Back"},
 		{ButtonName: "X", HelpText: "Save Filter"},
 		{ButtonName: "A", HelpText: "Select"},
+	}
+
+	if len(phfs.PlayHistoryFilterList) > 0 {
+		options.FooterHelpItems = append([]gaba.FooterHelpItem{{ButtonName: "B", HelpText: "Back"},}, options.FooterHelpItems...)
 	}
 
 	selection, err := gaba.List(options)
@@ -124,5 +127,6 @@ func (phfs PlayHistoryFilterScreen) Draw() (item interface{}, exitCode int, e er
 		return newFilter, 0, nil
 	}
 
+	state.UpdateCurrentMenuPosition(selection.Unwrap().SelectedIndex, selection.Unwrap().VisiblePosition)
 	return nil, 2, nil
 }

--- a/ui/play_history_filter.go
+++ b/ui/play_history_filter.go
@@ -8,6 +8,7 @@ import (
 	"nextui-game-manager/state"
 	"nextui-game-manager/utils"
 	"qlova.tech/sum"
+	"strings"
 )
 
 type PlayHistoryFilterScreen struct {
@@ -69,14 +70,21 @@ func (phfs PlayHistoryFilterScreen) Draw() (item interface{}, exitCode int, e er
 	romIds := []int{}
 	if len(phfs.GameAggregate.Id) > 0 {
 		romIds = phfs.GameAggregate.Id
-		title = title + " (" + phfs.GameAggregate.Name[:min(10, len(phfs.GameAggregate.Name))] + ")"
+		title = title + " (" + phfs.GameAggregate.Name + ")"
 	} else if phfs.Console != "" {
 		gamePlayMap, _, _ := state.GetPlayMaps()
 		gamesList := gamePlayMap[phfs.Console]
 		for _, game := range gamesList {
 			romIds = append(romIds, game.Id...)
 		}
-		title = title + " (" + phfs.Console[:min(10, len(phfs.Console))] + ")"
+
+		startIndex := strings.LastIndex(phfs.Console, "(")
+		endIndex := strings.LastIndex(phfs.Console, ")")
+		if startIndex == -1 || endIndex == -1 || startIndex >= endIndex {
+			title = title + " (" + phfs.Console + ")"
+		} else {
+			title = title + phfs.Console[startIndex : endIndex+1]
+		}
 	}
 
 	filterList := []models.PlayHistorySearchFilter{}

--- a/ui/play_history_game_details.go
+++ b/ui/play_history_game_details.go
@@ -70,17 +70,10 @@ func (ptgds PlayHistoryGameDetailsScreen) Name() sum.Int[models.ScreenName] {
 func (ptgds PlayHistoryGameDetailsScreen) Draw() (selection interface{}, exitCode int, e error) {
 	logger := common.GetLoggerInstance()
 
-	var consolePlayMap map[string]int
-	var totalPlay int 
-	var title string
-	if len(ptgds.PlayHistoryFilterList) == 0 {
-		_, consolePlayMap, totalPlay = state.GetPlayMaps()
-		title = ptgds.GameAggregate.Name
-	} else {
-		currentFilter := ptgds.PlayHistoryFilterList[len(ptgds.PlayHistoryFilterList)-1]
-		_, consolePlayMap, totalPlay = utils.GenerateCurrentGameStats(currentFilter.SqlFilter)
-		title = fmt.Sprintf("%s : %s", currentFilter.DisplayName, ptgds.GameAggregate.Name)
-	}
+	gamePlayMap, consolePlayMap, totalPlay := state.GetPlayMaps()
+	title := ptgds.GameAggregate.Name
+
+	gameAggregate := utils.CollectGameAggregateFromGameName(ptgds.GameAggregate.Name, ptgds.Console, gamePlayMap)
 
 	var sections []gaba.Section
 
@@ -88,13 +81,13 @@ func (ptgds PlayHistoryGameDetailsScreen) Draw() (selection interface{}, exitCod
 		title,
 		[]gaba.MetadataItem{
 			{Label: "Console", 			Value: ptgds.Console},
-			{Label: "First Played", 	Value: ptgds.GameAggregate.FirstPlayedTime.Format(time.UnixDate)},
-			{Label: "Last Played", 		Value: ptgds.GameAggregate.LastPlayedTime.Format(time.UnixDate)},
-			{Label: "Play Sessions", 	Value: strconv.Itoa(ptgds.GameAggregate.PlayCountTotal)},
-			{Label: "Total Play Time", 	Value: utils.ConvertSecondsToHumanReadable(ptgds.GameAggregate.PlayTimeTotal)},
-			{Label: "Average Session", 	Value: utils.ConvertSecondsToHumanReadable(ptgds.GameAggregate.PlayTimeTotal/ptgds.GameAggregate.PlayCountTotal)},
-			{Label: "Pct of Total", 	Value: fmt.Sprintf("%.2f%%", (float64(ptgds.GameAggregate.PlayTimeTotal)/float64(totalPlay))*100)},
-			{Label: "Pct of Console", 	Value: fmt.Sprintf("%.2f%%", (float64(ptgds.GameAggregate.PlayTimeTotal)/float64(consolePlayMap[ptgds.Console]))*100)},
+			{Label: "First Played", 	Value: gameAggregate.FirstPlayedTime.Format(time.UnixDate)},
+			{Label: "Last Played", 		Value: gameAggregate.LastPlayedTime.Format(time.UnixDate)},
+			{Label: "Play Sessions", 	Value: strconv.Itoa(gameAggregate.PlayCountTotal)},
+			{Label: "Total Play Time", 	Value: utils.ConvertSecondsToHumanReadable(gameAggregate.PlayTimeTotal)},
+			{Label: "Average Session", 	Value: utils.ConvertSecondsToHumanReadable(gameAggregate.PlayTimeTotal/gameAggregate.PlayCountTotal)},
+			{Label: "Pct of Total", 	Value: fmt.Sprintf("%.2f%%", (float64(gameAggregate.PlayTimeTotal)/float64(totalPlay))*100)},
+			{Label: "Pct of Console", 	Value: fmt.Sprintf("%.2f%%", (float64(gameAggregate.PlayTimeTotal)/float64(consolePlayMap[ptgds.Console]))*100)},
 		},
 	))
 

--- a/ui/play_history_game_details.go
+++ b/ui/play_history_game_details.go
@@ -71,12 +71,10 @@ func (ptgds PlayHistoryGameDetailsScreen) Draw() (selection interface{}, exitCod
 	logger := common.GetLoggerInstance()
 
 	gamePlayMap, consolePlayMap, totalPlay := state.GetPlayMaps()
-	title := ptgds.GameAggregate.Name
-
-	gameAggregate := utils.CollectGameAggregateFromGameName(ptgds.GameAggregate.Name, ptgds.Console, gamePlayMap)
+	gameAggregate := utils.CollectGameAggregateFromGamePath(ptgds.GameAggregate.Path, ptgds.Console, gamePlayMap)
+	title := gameAggregate.Name
 
 	var sections []gaba.Section
-
 	sections = append(sections, gaba.NewInfoSection(
 		title,
 		[]gaba.MetadataItem{

--- a/ui/play_history_game_history.go
+++ b/ui/play_history_game_history.go
@@ -19,10 +19,11 @@ type PlayHistoryGameHistoryScreen struct {
 	RomDirectory         	shared.RomDirectory
 	PreviousRomDirectory 	shared.RomDirectory
 	PlayHistoryOrigin		bool
+	PlayHistoryFilterList	[]models.PlayHistorySearchFilter
 }
 
-func InitPlayHistoryGameHistoryScreen(console string, searchFilter string, gameAggregate models.PlayHistoryAggregate, game shared.Item, 
-	romDirectory shared.RomDirectory, previousRomDirectory shared.RomDirectory, playHistoryOrigin bool) PlayHistoryGameHistoryScreen {
+func InitPlayHistoryGameHistoryScreen(console string, searchFilter string, gameAggregate models.PlayHistoryAggregate, game shared.Item, romDirectory shared.RomDirectory, 
+	previousRomDirectory shared.RomDirectory, playHistoryOrigin bool, filterList []models.PlayHistorySearchFilter) PlayHistoryGameHistoryScreen {
 	return PlayHistoryGameHistoryScreen{
 		Console:              	console,
 		SearchFilter:         	searchFilter,
@@ -31,17 +32,25 @@ func InitPlayHistoryGameHistoryScreen(console string, searchFilter string, gameA
 		RomDirectory: 			romDirectory,
 		PreviousRomDirectory:	previousRomDirectory,
 		PlayHistoryOrigin: 		playHistoryOrigin,
+		PlayHistoryFilterList: 	filterList,
 	}
 }
 
-func (ptgls PlayHistoryGameHistoryScreen) Name() sum.Int[models.ScreenName] {
+func (ptghs PlayHistoryGameHistoryScreen) Name() sum.Int[models.ScreenName] {
 	return models.ScreenNames.PlayHistoryGameHistory
 }
 
 func (ptghs PlayHistoryGameHistoryScreen) Draw() (item interface{}, exitCode int, e error) {
-	title := ptghs.GameAggregate.Name + " Play History"
-
-	playHistory := utils.GenerateSingleGameGranularRecords(ptghs.GameAggregate.Id)
+	var playHistory []models.PlayHistoryGranular
+	var title string
+	if len(ptghs.PlayHistoryFilterList) == 0 {
+		playHistory = utils.GenerateSingleGameGranularRecords(ptghs.GameAggregate.Id, "")
+		title = ptghs.GameAggregate.Name
+	} else {
+		currentFilter := ptghs.PlayHistoryFilterList[len(ptghs.PlayHistoryFilterList)-1]
+		playHistory = utils.GenerateSingleGameGranularRecords(ptghs.GameAggregate.Id, currentFilter.SqlFilter)
+		title = fmt.Sprintf("%s : %s", currentFilter.DisplayName, ptghs.GameAggregate.Name)
+	}
 
 	var menuItems []gaba.MenuItem
 	for _, playRecord := range playHistory {
@@ -64,37 +73,27 @@ func (ptghs PlayHistoryGameHistoryScreen) Draw() (item interface{}, exitCode int
 
 	options.SmallTitle = true
 	options.EmptyMessage = "No Play Records Found"
-	//options.EnableAction = true
+	options.EnableAction = true
 	options.FooterHelpItems = []gaba.FooterHelpItem{
 		{ButtonName: "B", HelpText: "Back"},
-		//{ButtonName: "X", HelpText: "Actions"},
+		{ButtonName: "X", HelpText: "Filter"},
 		//{ButtonName: "A", HelpText: "Update"},
 	}
 
-	// selection, err := gaba.List(options)
-	_, err := gaba.List(options)
+	selection, err := gaba.List(options)
 	if err != nil {
 		return nil, -1, err
 	}
 
-	// if selection.IsSome() && selection.Unwrap().ActionTriggered {
-	// 	state.UpdateCurrentMenuPosition(selection.Unwrap().SelectedIndex, selection.Unwrap().VisiblePosition)
-	// 	query, err := gaba.Keyboard("")
-
-	// 	if err != nil {
-	// 		return nil, 1, err
-	// 	}
-
-	// 	if query.IsSome() {
-	// 		return query.Unwrap(), 4, nil
-	// 	}
-
-	// 	return nil, 4, nil
-	// } else if selection.IsSome() && !selection.Unwrap().ActionTriggered && selection.Unwrap().SelectedIndex != -1 {
-	// 	state.UpdateCurrentMenuPosition(selection.Unwrap().SelectedIndex, selection.Unwrap().VisiblePosition)
-	// 	game := selection.Unwrap().SelectedItem.Metadata.(string)
-	// 	return game, 0, nil
-	// }
+	if selection.IsSome() && selection.Unwrap().ActionTriggered {
+		state.UpdateCurrentMenuPosition(selection.Unwrap().SelectedIndex, selection.Unwrap().VisiblePosition)
+		return nil, 4, nil
+	} else if selection.IsSome() && !selection.Unwrap().ActionTriggered && selection.Unwrap().SelectedIndex != -1 {
+		state.UpdateCurrentMenuPosition(selection.Unwrap().SelectedIndex, selection.Unwrap().VisiblePosition)
+		// game := selection.Unwrap().SelectedItem.Metadata.(string)
+		// return game, 0, nil
+		return nil, 0, nil
+	}
 
 	return nil, 2, nil
 }

--- a/ui/play_history_game_history.go
+++ b/ui/play_history_game_history.go
@@ -49,7 +49,7 @@ func (ptghs PlayHistoryGameHistoryScreen) Draw() (item interface{}, exitCode int
 	} else {
 		currentFilter := ptghs.PlayHistoryFilterList[len(ptghs.PlayHistoryFilterList)-1]
 		playHistory = utils.GenerateSingleGameGranularRecords(ptghs.GameAggregate.Id, currentFilter.SqlFilter)
-		title = fmt.Sprintf("%s : %s", currentFilter.DisplayName, ptghs.GameAggregate.Name)
+		title = fmt.Sprintf("%s: %s", currentFilter.DisplayName, ptghs.GameAggregate.Name)
 	}
 
 	var menuItems []gaba.MenuItem

--- a/ui/play_history_game_list.go
+++ b/ui/play_history_game_list.go
@@ -37,7 +37,7 @@ func (ptgls PlayHistoryGamesListScreen) Draw() (item interface{}, exitCode int, 
 	} else {
 		currentFilter := ptgls.PlayHistoryFilterList[len(ptgls.PlayHistoryFilterList)-1]
 		gamePlayMap, consoleMap, _ = utils.GenerateCurrentGameStats(currentFilter.SqlFilter)
-		title = fmt.Sprintf("%s : %s", currentFilter.DisplayName, ptgls.Console)
+		title = fmt.Sprintf("%s: %s", currentFilter.DisplayName, ptgls.Console)
 	}
 
 	gamesList := gamePlayMap[ptgls.Console]

--- a/ui/play_history_game_list.go
+++ b/ui/play_history_game_list.go
@@ -10,14 +10,14 @@ import (
 )
 
 type PlayHistoryGamesListScreen struct {
-	Console         string
-	SearchFilter	string
+	Console         		string
+	PlayHistoryFilterList	[]models.PlayHistorySearchFilter
 }
 
-func InitPlayHistoryGamesListScreen(console string, searchFilter string) PlayHistoryGamesListScreen {
+func InitPlayHistoryGamesListScreen(console string, filterList []models.PlayHistorySearchFilter) PlayHistoryGamesListScreen {
 	return PlayHistoryGamesListScreen{
-		Console:              console,
-		SearchFilter:         searchFilter,
+		Console:              	console,
+		PlayHistoryFilterList:  filterList,
 	}
 }
 
@@ -27,16 +27,20 @@ func (ptgls PlayHistoryGamesListScreen) Name() sum.Int[models.ScreenName] {
 
 func (ptgls PlayHistoryGamesListScreen) Draw() (item interface{}, exitCode int, e error) {
 	appState := state.GetAppState()
-	gamePlayMap, consoleMap, _ := state.GetPlayMaps()
 
-	title := fmt.Sprintf("%.1fH : %s", float64(consoleMap[ptgls.Console])/3600.0, ptgls.Console)
+	var gamePlayMap map[string][]models.PlayHistoryAggregate
+	var consoleMap map[string]int
+	var title string
+	if len(ptgls.PlayHistoryFilterList) == 0 {
+		gamePlayMap, consoleMap, _ = state.GetPlayMaps()
+		title = fmt.Sprintf("%.1fH : %s", float64(consoleMap[ptgls.Console])/3600.0, ptgls.Console)
+	} else {
+		currentFilter := ptgls.PlayHistoryFilterList[len(ptgls.PlayHistoryFilterList)-1]
+		gamePlayMap, consoleMap, _ = utils.GenerateCurrentGameStats(currentFilter.SqlFilter)
+		title = fmt.Sprintf("%s : %.1fH : %s", currentFilter.DisplayName, float64(consoleMap[ptgls.Console])/3600.0, ptgls.Console)
+	}
 
 	gamesList := gamePlayMap[ptgls.Console]
-
-	if ptgls.SearchFilter != "" {
-		title = "[Search: \"" + ptgls.SearchFilter + "\"]"
-		gamesList = utils.FilterPlayList(gamesList, ptgls.SearchFilter)
-	}
 
 	var menuItems []gaba.MenuItem
 	collectionMap := state.GetCollectionMap()
@@ -74,7 +78,7 @@ func (ptgls PlayHistoryGamesListScreen) Draw() (item interface{}, exitCode int, 
 	options.EnableAction = true
 	options.FooterHelpItems = []gaba.FooterHelpItem{
 		{ButtonName: "B", HelpText: "Back"},
-		{ButtonName: "X", HelpText: "Search"},
+		{ButtonName: "X", HelpText: "Filter"},
 		{ButtonName: "Menu", HelpText: "Help"},
 		{ButtonName: "A", HelpText: "Details"},
 	}
@@ -95,16 +99,6 @@ func (ptgls PlayHistoryGamesListScreen) Draw() (item interface{}, exitCode int, 
 
 	if selection.IsSome() && selection.Unwrap().ActionTriggered {
 		state.UpdateCurrentMenuPosition(selection.Unwrap().SelectedIndex, selection.Unwrap().VisiblePosition)
-		query, err := gaba.Keyboard("")
-
-		if err != nil {
-			return nil, 1, err
-		}
-
-		if query.IsSome() {
-			return query.Unwrap(), 4, nil
-		}
-
 		return nil, 4, nil
 	} else if selection.IsSome() && !selection.Unwrap().ActionTriggered && selection.Unwrap().SelectedIndex != -1 {
 		state.UpdateCurrentMenuPosition(selection.Unwrap().SelectedIndex, selection.Unwrap().VisiblePosition)

--- a/ui/play_history_game_list.go
+++ b/ui/play_history_game_list.go
@@ -37,7 +37,7 @@ func (ptgls PlayHistoryGamesListScreen) Draw() (item interface{}, exitCode int, 
 	} else {
 		currentFilter := ptgls.PlayHistoryFilterList[len(ptgls.PlayHistoryFilterList)-1]
 		gamePlayMap, consoleMap, _ = utils.GenerateCurrentGameStats(currentFilter.SqlFilter)
-		title = fmt.Sprintf("%s : %.1fH : %s", currentFilter.DisplayName, float64(consoleMap[ptgls.Console])/3600.0, ptgls.Console)
+		title = fmt.Sprintf("%s : %s", currentFilter.DisplayName, ptgls.Console)
 	}
 
 	gamesList := gamePlayMap[ptgls.Console]

--- a/ui/play_history_list.go
+++ b/ui/play_history_list.go
@@ -37,7 +37,7 @@ func (ptls PlayHistoryListScreen) Draw() (item interface{}, exitCode int, e erro
 	} else {
 		currentFilter := ptls.PlayHistoryFilterList[len(ptls.PlayHistoryFilterList)-1]
 		_, consolePlayMap, totalPlay = utils.GenerateCurrentGameStats(currentFilter.SqlFilter)
-		title = fmt.Sprintf("%s : %.1f Total Hours Played", currentFilter.DisplayName, float64(totalPlay)/3600.0)
+		title = fmt.Sprintf("%s: %.1f Total Hours Played", currentFilter.DisplayName, float64(totalPlay)/3600.0)
 	}
 
 	if consolePlayMap == nil || len(consolePlayMap) == 0 {

--- a/ui/play_history_list.go
+++ b/ui/play_history_list.go
@@ -1,19 +1,25 @@
 package ui
 
 import (
+	"cmp"
 	"fmt"
 	gaba "github.com/UncleJunVIP/gabagool/pkg/gabagool"
 	"nextui-game-manager/models"
 	"nextui-game-manager/state"
+	"nextui-game-manager/utils"
 	"qlova.tech/sum"
 	"maps"
 	"slices"
 )
 
-type PlayHistoryListScreen struct {}
+type PlayHistoryListScreen struct {
+	PlayHistoryFilterList	[]models.PlayHistorySearchFilter
+}
 
-func InitPlayHistoryListScreen() PlayHistoryListScreen {
-	return PlayHistoryListScreen{}
+func InitPlayHistoryListScreen(filterList []models.PlayHistorySearchFilter) PlayHistoryListScreen {
+	return PlayHistoryListScreen{
+		PlayHistoryFilterList: filterList,
+	}
 }
 
 func (ptls PlayHistoryListScreen) Name() sum.Int[models.ScreenName] {
@@ -22,16 +28,26 @@ func (ptls PlayHistoryListScreen) Name() sum.Int[models.ScreenName] {
 
 // Lists available play History consoles
 func (ptls PlayHistoryListScreen) Draw() (item interface{}, exitCode int, e error) {
-	_, consolePlayMap, totalPlay := state.GetPlayMaps()
-
-	title := fmt.Sprintf("%.1f Total Hours Played", float64(totalPlay)/3600.0)
+	var consolePlayMap map[string]int
+	var totalPlay int 
+	var title string
+	if len(ptls.PlayHistoryFilterList) == 0 {
+		_, consolePlayMap, totalPlay = state.GetPlayMaps()
+		title = fmt.Sprintf("%.1f Total Hours Played", float64(totalPlay)/3600.0)
+	} else {
+		currentFilter := ptls.PlayHistoryFilterList[len(ptls.PlayHistoryFilterList)-1]
+		_, consolePlayMap, totalPlay = utils.GenerateCurrentGameStats(currentFilter.SqlFilter)
+		title = fmt.Sprintf("%s : %.1f Total Hours Played", currentFilter.DisplayName, float64(totalPlay)/3600.0)
+	}
 
 	if consolePlayMap == nil || len(consolePlayMap) == 0 {
 		return nil, 404, nil
 	}
 
 	var menuItems []gaba.MenuItem
-	consoles := slices.Sorted(maps.Keys(consolePlayMap))
+	consoles := slices.SortedStableFunc(maps.Keys(consolePlayMap), func(a, b string) int {
+		return cmp.Compare(consolePlayMap[b], consolePlayMap[a])
+	})
 	for _, console := range consoles {
 		consoleItem := gaba.MenuItem{
 			Text:     fmt.Sprintf("%.1fH : %s", min(9999, float64(consolePlayMap[console])/3600.0), console),
@@ -51,6 +67,7 @@ func (ptls PlayHistoryListScreen) Draw() (item interface{}, exitCode int, e erro
 	options.EnableAction = true
 	options.FooterHelpItems = []gaba.FooterHelpItem{
 		{ButtonName: "B", HelpText: "Back"},
+		{ButtonName: "X", HelpText: "Filter"},
 		{ButtonName: "A", HelpText: "Select"},
 	}
 
@@ -59,7 +76,10 @@ func (ptls PlayHistoryListScreen) Draw() (item interface{}, exitCode int, e erro
 		return nil, -1, err
 	}
 
-	if selection.IsSome() && !selection.Unwrap().ActionTriggered && selection.Unwrap().SelectedIndex != -1 {
+	if selection.IsSome() && selection.Unwrap().ActionTriggered {
+		state.UpdateCurrentMenuPosition(selection.Unwrap().SelectedIndex, selection.Unwrap().VisiblePosition)
+		return nil, 4, nil
+	} else if selection.IsSome() && !selection.Unwrap().ActionTriggered && selection.Unwrap().SelectedIndex != -1 {
 		state.UpdateCurrentMenuPosition(selection.Unwrap().SelectedIndex, selection.Unwrap().VisiblePosition)
 		console := selection.Unwrap().SelectedItem.Metadata.(string)
 		return console, 0, nil

--- a/ui/play_history_list.go
+++ b/ui/play_history_list.go
@@ -65,6 +65,7 @@ func (ptls PlayHistoryListScreen) Draw() (item interface{}, exitCode int, e erro
 	options.VisibleStartIndex = visibleStartIndex
 
 	options.EnableAction = true
+	options.SmallTitle = true
 	options.FooterHelpItems = []gaba.FooterHelpItem{
 		{ButtonName: "B", HelpText: "Back"},
 		{ButtonName: "X", HelpText: "Filter"},

--- a/ui/tools.go
+++ b/ui/tools.go
@@ -36,6 +36,11 @@ func (ts ToolsScreen) Draw() (value interface{}, exitCode int, e error) {
 	})
 
 	options := gabagool.DefaultListOptions("Tools", menuItems)
+
+	selectedIndex, visibleStartIndex := state.GetCurrentMenuPosition()
+	options.SelectedIndex = selectedIndex
+	options.VisibleStartIndex = visibleStartIndex
+	
 	options.FooterHelpItems = []gabagool.FooterHelpItem{
 		{ButtonName: "B", HelpText: "Back"},
 		{ButtonName: "A", HelpText: "Select"},

--- a/utils/game_tracker.go
+++ b/utils/game_tracker.go
@@ -252,9 +252,9 @@ func GenFiltersList(romIds []int, searchFilterString string, existingFilterType 
 	newFilterFormat := ""
 	switch existingFilterType {
 	case YearMonth:
-		newFilterFormat = "STRFTIME('%Y.%m.%d', DATETIME(play_activity.created_at, 'unixepoch'))"
+		newFilterFormat = "STRFTIME('%Y.%m.%d', DATETIME(play_activity.created_at, 'unixepoch', 'localtime'))"
 	default:
-		newFilterFormat = "STRFTIME('%Y.%m', DATETIME(play_activity.created_at, 'unixepoch'))"
+		newFilterFormat = "STRFTIME('%Y.%m', DATETIME(play_activity.created_at, 'unixepoch', 'localtime'))"
 	}
 
 	rows, err := db.Query("SELECT " + newFilterFormat + " as new_filter, " + 

--- a/utils/game_tracker.go
+++ b/utils/game_tracker.go
@@ -190,19 +190,23 @@ func FindRomHomeFromAggregate(gameAggregate models.PlayHistoryAggregate, showArc
 
 func CollectGameAggregateFromGame(gameItem shared.Item, gamePlayMap map[string][]models.PlayHistoryAggregate) (models.PlayHistoryAggregate, string) {
 	console := extractItemConsoleName(gameItem)
+	return CollectGameAggregateFromGameName(gameItem.DisplayName, console, gamePlayMap), console
+}
+
+func CollectGameAggregateFromGameName(gameName string, console string, gamePlayMap map[string][]models.PlayHistoryAggregate) (models.PlayHistoryAggregate) {
 	PlayHistoryList := gamePlayMap[console]
 
 	for _, gameAggregate := range PlayHistoryList {
-		if gameAggregate.Name == gameItem.DisplayName {
-			return gameAggregate, console
+		if gameAggregate.Name == gameName {
+			return gameAggregate
 		}
 	}
 
 	return models.PlayHistoryAggregate{
-		Name: gameItem.DisplayName,
+		Name: gameName,
 		PlayTimeTotal: 0,
 		PlayCountTotal: 0,
-	}, console
+	}
 }
 
 func convertIntListToStringList(intList []int) []string {

--- a/utils/game_tracker.go
+++ b/utils/game_tracker.go
@@ -213,7 +213,75 @@ func convertIntListToStringList(intList []int) []string {
 	return stringList
 }
 
-func GenerateSingleGameGranularRecords(romIds []int) []models.PlayHistoryGranular {
+const (
+	NoFilter		= 0   // No filter
+	YearMonth       = 1   // YearMonth Filter
+)
+
+func GenFiltersList(romIds []int, searchFilterString string, existingFilterType int) []models.PlayHistorySearchFilter {
+	logger := common.GetLoggerInstance()
+	db, err := openGameTrackerDB()
+	if err != nil {
+		return nil
+	}
+	defer closeDB(db)
+
+	// If any roms are selected by parents, filter for those roms
+	romWhereStr := ""
+	if len(romIds) > 0 {
+		romWhereStr = " rom_id in ('" + strings.Join(convertIntListToStringList(romIds), "','") + "') "
+	}
+
+	// rom filters or search filters are present, include WHERE clause
+	whereStr := ""
+	if romWhereStr != "" || searchFilterString != "" {
+		whereStr = " WHERE "
+	}
+
+	// rom filters and search filters are present, include AND clause
+	andStr := ""
+	if romWhereStr != "" && searchFilterString != "" {
+		andStr = " AND "
+	}
+
+	// Generate date string modifier constructs
+	newFilterFormat := ""
+	switch existingFilterType {
+	case YearMonth:
+		newFilterFormat = "STRFTIME('%%Y.%%m.%%d', DATETIME(created_at, 'unixepoch'))"
+	default:
+		newFilterFormat = "STRFTIME('%%Y.%%m', DATETIME(created_at, 'unixepoch'))"
+	}
+
+	rows, err := db.Query("SELECT " + newFilterFormat + " as new_filter, " + 
+						  "sum(play_time) as play_time " +
+        				  "FROM play_activity " +
+						  whereStr + romWhereStr + andStr + searchFilterString +
+        				  "GROUP BY " + newFilterFormat)
+	defer rows.Close()
+
+	var filterList []models.PlayHistorySearchFilter
+	for rows.Next() {
+		var newFilter 	string
+		var playTime 	int
+		if err := rows.Scan(&newFilter, &playTime); err != nil {
+			logger.Error("Failed to load game tracker data", zap.Error(err))
+		}
+
+		singleFilter := models.PlayHistorySearchFilter{
+			DisplayName:	newFilter,
+			SqlFilter: 		newFilterFormat + " = '" + newFilter + "'",
+			FilterType:		existingFilterType + 1,
+			PlayTime:		playTime,
+		}
+
+		filterList = append(filterList, singleFilter)
+	}
+
+	return filterList
+}
+
+func GenerateSingleGameGranularRecords(romIds []int, searchFilter string) []models.PlayHistoryGranular {
 	if len(romIds) == 0 {
 		return nil
 	}
@@ -227,9 +295,15 @@ func GenerateSingleGameGranularRecords(romIds []int) []models.PlayHistoryGranula
 
 	romIdString := strings.Join(convertIntListToStringList(romIds), "','")
 
+	whereMod := ""
+	if searchFilter != "" {
+		whereMod = " and " + searchFilter + " "
+	}
+
 	rows, err := db.Query("SELECT play_time, created_at, updated_at " +
         				  "FROM play_activity " +
 						  "WHERE rom_id in ('"+romIdString+"') " +
+						  whereMod +
         				  "ORDER BY created_at")
 	defer rows.Close()
 
@@ -253,13 +327,18 @@ func GenerateSingleGameGranularRecords(romIds []int) []models.PlayHistoryGranula
 	return granularList
 }
 
-func GenerateCurrentGameStats() (map[string][]models.PlayHistoryAggregate, map[string]int, int) {
+func GenerateCurrentGameStats(searchFilter string) (map[string][]models.PlayHistoryAggregate, map[string]int, int) {
 	logger := common.GetLoggerInstance()
 	db, err := openGameTrackerDB()
 	if err != nil {
 		return nil, nil, 0
 	}
 	defer closeDB(db)
+
+	whereMod := ""
+	if searchFilter != "" {
+		whereMod = " WHERE " + searchFilter + " "
+	}
 
 	rows, err := db.Query("SELECT rom.id, rom.name, rom.file_path, " +
 						  "SUM(play_activity.play_time) AS play_time_total, " +
@@ -269,6 +348,7 @@ func GenerateCurrentGameStats() (map[string][]models.PlayHistoryAggregate, map[s
         				  "FROM rom " +
 						  "LEFT JOIN play_activity " +
 						  "ON rom.id = play_activity.rom_id " +
+						  whereMod +
         				  "GROUP BY rom.id " +
         				  "HAVING play_time_total > 0 " +
         				  "ORDER BY play_time_total DESC")

--- a/utils/game_tracker.go
+++ b/utils/game_tracker.go
@@ -248,9 +248,9 @@ func GenFiltersList(romIds []int, searchFilterString string, existingFilterType 
 	newFilterFormat := ""
 	switch existingFilterType {
 	case YearMonth:
-		newFilterFormat = "STRFTIME('%%Y.%%m.%%d', DATETIME(created_at, 'unixepoch'))"
+		newFilterFormat = "STRFTIME('%Y.%m.%d', DATETIME(created_at, 'unixepoch'))"
 	default:
-		newFilterFormat = "STRFTIME('%%Y.%%m', DATETIME(created_at, 'unixepoch'))"
+		newFilterFormat = "STRFTIME('%Y.%m', DATETIME(created_at, 'unixepoch'))"
 	}
 
 	rows, err := db.Query("SELECT " + newFilterFormat + " as new_filter, " + 

--- a/utils/game_tracker.go
+++ b/utils/game_tracker.go
@@ -190,20 +190,20 @@ func FindRomHomeFromAggregate(gameAggregate models.PlayHistoryAggregate, showArc
 
 func CollectGameAggregateFromGame(gameItem shared.Item, gamePlayMap map[string][]models.PlayHistoryAggregate) (models.PlayHistoryAggregate, string) {
 	console := extractItemConsoleName(gameItem)
-	return CollectGameAggregateFromGameName(gameItem.DisplayName, console, gamePlayMap), console
+	return CollectGameAggregateFromGamePath(gameItem.Path, console, gamePlayMap), console
 }
 
-func CollectGameAggregateFromGameName(gameName string, console string, gamePlayMap map[string][]models.PlayHistoryAggregate) (models.PlayHistoryAggregate) {
+func CollectGameAggregateFromGamePath(gamePath string, console string, gamePlayMap map[string][]models.PlayHistoryAggregate) (models.PlayHistoryAggregate) {
 	PlayHistoryList := gamePlayMap[console]
 
 	for _, gameAggregate := range PlayHistoryList {
-		if gameAggregate.Name == gameName {
+		if gameAggregate.Path == gamePath {
 			return gameAggregate
 		}
 	}
 
 	return models.PlayHistoryAggregate{
-		Name: gameName,
+		Name: extractGameName(gamePath),
 		PlayTimeTotal: 0,
 		PlayCountTotal: 0,
 	}
@@ -475,6 +475,15 @@ func extractItemConsoleName(gameItem shared.Item) string {
 		return ""
 	}
 	return pathSplit[4]
+}
+
+func extractGameName(romFilePath string) string {
+	if romFilePath == "" {
+		return romFilePath
+	}
+	pathParts := strings.Split(romFilePath, "/")
+	
+	return removeFileExtension(pathParts[len(pathParts)-1])
 }
 
 func ConvertSecondsToHumanReadable(gameTimeSeconds int) string {

--- a/utils/game_tracker.go
+++ b/utils/game_tracker.go
@@ -248,13 +248,13 @@ func GenFiltersList(romIds []int, searchFilterString string, existingFilterType 
 	newFilterFormat := ""
 	switch existingFilterType {
 	case YearMonth:
-		newFilterFormat = "STRFTIME('%Y.%m.%d', DATETIME(created_at, 'unixepoch'))"
+		newFilterFormat = "STRFTIME('%Y.%m.%d', DATETIME(play_activity.created_at, 'unixepoch'))"
 	default:
-		newFilterFormat = "STRFTIME('%Y.%m', DATETIME(created_at, 'unixepoch'))"
+		newFilterFormat = "STRFTIME('%Y.%m', DATETIME(play_activity.created_at, 'unixepoch'))"
 	}
 
 	rows, err := db.Query("SELECT " + newFilterFormat + " as new_filter, " + 
-						  "sum(play_time) as play_time " +
+						  "sum(play_activity.play_time) as play_time " +
         				  "FROM play_activity " +
 						  whereStr + romWhereStr + andStr + searchFilterString +
         				  "GROUP BY " + newFilterFormat)


### PR DESCRIPTION
Adds a filtering action in play history. 

In any play history listing, press X to view date buckets for your current selection. You can filter for a specific month, or down to a specific date, then press X again to return to your existing play history list with the filter applied. 

To remove an applied filter, return to the filter screen with X, use B to back out of filter buckets, then press X again to return to your play history.

Filters are retained throughout the play history tool until exiting it.